### PR TITLE
finland: remove tezagm

### DIFF
--- a/europe/finland.md
+++ b/europe/finland.md
@@ -2,11 +2,6 @@
 
 Add the strings from the below to the `Peers: [],` list of your config file (comma separated) to connect to these nodes.
 
-* Kouvola, Netplaza, operated by [Mikaela](https://mikaela.info/)  
-    * `"tcp://tezagm.mikaela.info:47471"`
-
-  NOTE: Connection is 0,2 Mbps down / 10 Mbps up most of days (cottage Raspberry Pi B+)
-
 * Ulvila, operated by [ano](https://github.com/ano0)
     * `"tcp://185.87.111.202:8080"`
 


### PR DESCRIPTION
The network connection at Tezagm's current home is being discontinued
and it's moving to my family which is behind CGN and often without IPv6
connectivity, so I have to remove it from here.

I expect it to continue working as a Tor peer when it's connected at its
new home.