### PR TITLE
 Europe/Germany: CWINFO Node Port Fix

### DIFF
--- a/europe/germany.md
+++ b/europe/germany.md
@@ -7,8 +7,8 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://51.75.65.46:65352`
 
 * Limburg, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tcp://54.38.157.232:37145`
-  * `tcp://[2001:41d0:701:1100::36e]:37145`
+  * `tcp://54.38.157.232:39593`
+  * `tcp://[2001:41d0:701:1100::36e]:39593`
 
 * Baden-Baden, IONOS, operated by [jcgruenhage](https://jcg.re/)  
   * `tcp://82.165.69.111:61216`


### PR DESCRIPTION
Previously there was unused port in list and fixed port is in this PR