### PR TITLE
Europe/Finland: Adding CWINFO's peer

### DIFF
--- a/europe/finland.md
+++ b/europe/finland.md
@@ -3,7 +3,7 @@
 Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
-* Ulvila, operated by [ano](https://github.com/ano0)
+* Ulvila, Tavu Cloud, operated by [ano](https://github.com/ano0)
   * `tcp://185.87.111.202:8080`
   
 * Ulvila, Tavu Cloud, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)

--- a/europe/finland.md
+++ b/europe/finland.md
@@ -5,6 +5,10 @@ Yggdrasil configuration file to peer with these nodes.
 
 * Ulvila, operated by [ano](https://github.com/ano0)
   * `tcp://185.87.111.202:8080`
+  
+* Ulvila, Tavu Cloud, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
+  * `tcp://185.87.111.218:60384`
+  * `tcp://[2a05:b9c0::1:0:d3]:60384`
 
 * Tuusula, Hetzner, operated by [sin](https://2f30.org)
   * `tcp://95.216.146.86:12080`


### PR DESCRIPTION
## CWINFO (@cwinfo)
fi1.servers.devices.cwinfo.net
Ulvila, Tavu Cloud