### PR TITLE
europe/germany.md: remove y.korsin.do.mikaela.info

### DIFF
--- a/europe/germany.md
+++ b/europe/germany.md
@@ -13,10 +13,6 @@ Yggdrasil configuration file to peer with these nodes.
 * Baden-Baden, IONOS, operated by [jcgruenhage](https://jcg.re/)  
   * `tcp://82.165.69.111:61216`
 
-* Frankfurt, DigitalOcean, operated by [Mikaela](https://mikaela.info/)
-  * `tcp://46.101.250.19:48286`
-  * `tcp://[2a03:b0c0:3:d0::31f:d001]:48286`
-
 * Falkenstein, Hetzner, FSN1-DC7, operated by [Kipari](https://christoffer.space)
   * `tcp://5.9.112.248:39444`
 


### PR DESCRIPTION
I have less than a month left of DigitalOcean credit so I will be taking
it offline permanently in near future. Luckily during these months more
peers have appeared in Germany.