### PR TITLE
Tor: add a public peer & note that another is currently down

### DIFF
--- a/other/tor.md
+++ b/other/tor.md
@@ -13,3 +13,6 @@ Note that the following assumes Tor is running locally and listening on the defa
 
 * HS3 (TCP-only, Hidden Service, v3), operated by [Mikaela](https://mikaela.info/)
   * `socks://127.0.0.1:9050/xvkw4rj7wzy7t75kkanr54zftudlbtpjbavxcsri5irkavclynaw3xqd.onion:1234`
+
+* HS3 (TCP-only, Hidden Service, v3), operated by [Mikaela](https://mikaela.info/) on behalf of [Pirate Party Finland](https://piraattipuolue.fi/en) ([Tor Metrics](https://metrics.torproject.org/rs.html#details/796338999A7E34CA4C0F2C6092618C82C0D335D9))
+  * `"socks://127.0.0.1:9050/x7dqdmjb7y5ykj4kgirwzj62wrrd3t5dv57oy7oyidnf7cpthd4k7ryd.onion:5222"`

--- a/other/tor.md
+++ b/other/tor.md
@@ -11,7 +11,7 @@ Note that the following assumes Tor is running locally and listening on the defa
 * HS3 (TCP-only, Hidden Service, v3), operated by [cathugger](http://cathug2kyi4ilneggumrenayhuhsvrgn6qv2y47bgeet42iivkpynqad.onion/contact.html)
   * `socks://localhost:9050/yggnekkmyitzepgl5ltdl277y5wdg36n4pc45sualo3yesm3usnuwyad.onion:1863`
 
-* HS3 (TCP-only, Hidden Service, v3), operated by [Mikaela](https://mikaela.info/)
+* HS3 (TCP-only, Hidden Service, v3), operated by [Mikaela](https://mikaela.info/) ***CURRENTLY DOWN***
   * `socks://127.0.0.1:9050/xvkw4rj7wzy7t75kkanr54zftudlbtpjbavxcsri5irkavclynaw3xqd.onion:1234`
 
 * HS3 (TCP-only, Hidden Service, v3), operated by [Mikaela](https://mikaela.info/) on behalf of [Pirate Party Finland](https://piraattipuolue.fi/en) ([Tor Metrics](https://metrics.torproject.org/rs.html#details/796338999A7E34CA4C0F2C6092618C82C0D335D9))


### PR DESCRIPTION
There are multiple Tor nodes on that server, so Tor Metrics shouldn't include Yggdrasil traffic which is on NonAnonymous instance. I took 5222 from `man torrc`'s section `LongLivedPorts` where it's one of the defaults and a port that is unlikely to go away due to being XMPP which is still used.

On Tezagm I don't know when I can investigate it better, I fear it's a dead SD card or something.