### PR TITLE
Add new peer in Singapore

### DIFF
--- a/asia/singapore.md
+++ b/asia/singapore.md
@@ -6,3 +6,5 @@ Yggdrasil configuration file to peer with these nodes.
 * Singapore, operated by passenger
   * `tcp://45.59.126.34:22301`
   * `tcp://[2406:d500:12:beef:4c38::1]:22301`
+* Singapore, operated by kivikakk
+  * `tcp://miriam.hrzn.ee:23320`

--- a/asia/singapore.md
+++ b/asia/singapore.md
@@ -6,5 +6,6 @@ Yggdrasil configuration file to peer with these nodes.
 * Singapore, operated by passenger
   * `tcp://45.59.126.34:22301`
   * `tcp://[2406:d500:12:beef:4c38::1]:22301`
+  
 * Singapore, operated by kivikakk
   * `tcp://miriam.hrzn.ee:23320`


### PR DESCRIPTION
The server's IP address oughtn't change, but using names works and it seems less fragile this way. Happy to swap for the IP if you don't like it. Not available on IPv6, alas. 😞 