### PR TITLE
i2p.md: add PPFI HQ machine

### DIFF
--- a/other/i2p.md
+++ b/other/i2p.md
@@ -7,3 +7,6 @@ Note that the following assumes I2P is running locally and has configured SOCKS 
 
 * ST32 (TCP-only, Standard I2P service, b32 address), operated by [cathugger](http://cathugger.i2p/contact.html)
   * `socks://localhost:4447/7mx6ztmimo5nrnmydjjtkr6maupknr3zlyr33umly22pqnivyxcq.b32.i2p:46944`
+
+* ST32 (TCP-only, Standard I2P service, b32 address, operated by [Mikaela](https://mikaela.info/) on behalf of [Pirate Party Finland](https://piraattipuolue.fi/en) ([Tor Metrics](https://metrics.torproject.org/rs.html#details/796338999A7E34CA4C0F2C6092618C82C0D335D9))
+  * `"socks://localhost:4447/gqt6l2wox5jndysfllrgdr6mp473t24mdi7f3iz6lugpzv3z67wq.b32.i2p:63412"`


### PR DESCRIPTION
This is my first I2P service, so I would appreciate checking that I did it correctly, I copied the syntax above.

The tunnel config: https://gitea.blesmrt.net/mikaela/shell-things/src/branch/master/etc/i2pd/tunnels.conf.d/yggdrasil-in.conf

I found the b32 address from i2pd.log, but most of times establishing connection to it seems to take a long time, and I am not sure if this is something wrong on my side or normal for less popular i2p services.

While the Tor Metrics part is a bit offtopic, I think it can be useful to include as it has information on whether the machine is up or not.