### PR TITLE
Deleted IPv6 for "Network Neighborhood"

### DIFF
--- a/europe/netherlands.md
+++ b/europe/netherlands.md
@@ -22,7 +22,6 @@ Yggdrasil configuration file to peer with these nodes.
 
 * Amsterdam, [Network Neighborhood](http://netwhood.online) public node, operated by [abslimit](http://netwhood.online/feedback/)
   * `tcp://51.15.99.80:50001`
-  * `tcp://[2001:bc8:4700:2000::6b29]:50001`
   
 * Dronten, operated by ne-vlezay80
   * `tcp://185.154.13.142:1198`


### PR DESCRIPTION
IPv6 changes often because of Scaleway politics.