### PR TITLE
[Peer Update] – Strasbourg, OVH, operated by cwinfo and cwchristerw

### DIFF
--- a/europe/france.md
+++ b/europe/france.md
@@ -13,10 +13,10 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://[2001:41d0:2:c44a:51:255:223:60]:10259`
 
 * Strasbourg, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tcp://46.105.92.61:62506`
-  * `tcp://[2001:41d0:401:3000::4227]:62506`
-  * `tls://46.105.92.61:46394`
-  * `tls://[2001:41d0:401:3000::4227]:46394`
+  * `tcp://46.105.92.61:52968`
+  * `tcp://[2001:41d0:401:3000::4227]:52968`
+  * `tls://46.105.92.61:39737`
+  * `tls://[2001:41d0:401:3000::4227]:39737`
 
 * Paris, Online SAS, operated by [R4SAS](https://github.com/r4sas)
   * `tcp://212.129.52.193:39565`


### PR DESCRIPTION
fr2.servers.devices.cwinfo.net