### PR TITLE
czechia.md: Remove one node in Prague

### DIFF
--- a/europe/czechia.md
+++ b/europe/czechia.md
@@ -7,10 +7,6 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://195.123.245.146:7743`
   * `tcp://[2a05:9403::8b]:7743`
 
-* Praha, centro-net.cz, operated by [carnhofdaki](https://github.com/carnhofdaki)
-  * `tcp://217.195.164.4:10000`
-  * `tls://217.195.164.4:10531`
-
 * Praha, vpsFree, operated by @ehmry
   * `tcp://37.205.14.171:46370`
   * `tcp://[2a03:3b40:fe:ab::1]:46370`


### PR DESCRIPTION
There was recently too much traffic reported. So turning it off.