### PR TITLE
Update russia.md

### DIFF
--- a/europe/russia.md
+++ b/europe/russia.md
@@ -4,11 +4,12 @@ Operators of Yggdrasil public peers in Russia should consider joining the [Russi
 
 Add connection strings from the below list to the `Peers: []` section of your Yggdrasil configuration file to peer with these nodes.
 
+
 ### Moscow
 * Moscow Oblast, Podolsk, [Network neighborhood](https://netwhood.online/) public node, ALDIS Telecom Ltd. [Feedback contacts](http://netwhood.online/feedback/). Operated by [abslimit](https://mstdn.netwhood.online/@abslimit)
   * `tcp://46.151.26.194:60575`
   * `tls://46.151.26.194:8443`
-  
+
 * Moscow, vps public node, operated by [TomasGl](https://github.com/TomasGlgg), *rate-limited to 200 Mbit/s*, ipv4/ipv6
   * `tcp://ygg.tomasgl.ru:61933`
   * `tls://ygg.tomasgl.ru:61944`
@@ -16,8 +17,8 @@ Add connection strings from the below list to the `Peers: []` section of your Yg
 * Moscow, vps public node, operated by [Nikat](https://t.me/nikat_meh)
   * `tcp://yggnode.cf:18228`
   * `tls://yggnode.cf:18229`
-  
-  * Moscow, vps public node, operated by [AveryanAlex](https://t.me/averyanalex) *Rate-limited to 75 Mbit/s*
+
+* Moscow, vps public node, operated by [AveryanAlex](https://t.me/averyanalex) *Rate-limited to 75 Mbit/s*
   * `tcp://37.230.116.83:5353`
   * `tcp://[2a01:230:2::208]:5353`
 
@@ -26,40 +27,44 @@ Add connection strings from the below list to the `Peers: []` section of your Yg
 * Saint Petersburg, loskiq public node, operated by [loskiq](https://loskiq.dev)
   * `tcp://ygg.loskiq.dev:17313`
   * `tls://ygg.loskiq.dev:17314`
-  
-  
+
+
 ### Yekaterinburg
 * Yekaterinburg, home user public node, operated by [pztrn](https://pztrn.name), *rate-limited to 100 Mbit/s*
   * `tcp://188.226.125.64:54321`
   * `tcp://[2a02:17d0:1b4:bddd::7]:54321`
-  
-  
+
+
 ### Ufa
 * Ufa, home user public node, operated by [tdemin](https://tdem.in), *rate-limited to 100 Mbit/s*
   * `tcp://lan.tdem.in:50001`
   * `tls://lan.tdem.in:50002`
-  
-  
+
+
 ### Novosibirsk
-* Novosibirsk, public node, operated by [Saiv46](https://t.me/Saiv46), *bandwidth from 200 Mbps to 1 Gbps*
-  * `tcp://91.206.93.65:1333`
-  * `tcp://[2a00:b700:2::6:69]:1333`
-  * `tls://91.206.93.65:1444`
-  * `tls://[2a00:b700:2::6:69]:1444`
+* Novosibirsk, public node, operated by [Saiv46](https://t.me/Saiv46), *rate-limited to 200 Mbps*
+  * `tcp://nsk.peering.flying-squid.host:8080?ed25519=f15dceb84a40697471b68f4c04b3620c734478a782e7d844fe2be6ff52ef1f6f`
+  * `tls://nsk.peering.flying-squid.host:8433?ed25519=f15dceb84a40697471b68f4c04b3620c734478a782e7d844fe2be6ff52ef1f6f`
+  * ~~`tcp://91.206.93.65:1333`~~ **(DEPRECATED)**
+  * ~~`tcp://[2a00:b700:2::6:69]:1333`~~ **(DEPRECATED)**
+  * ~~`tls://91.206.93.65:1444`~~ **(DEPRECATED)**
+  * ~~`tls://[2a00:b700:2::6:69]:1444`~~ **(DEPRECATED)**
 
 
 ### Irkutsk
-* Irkutsk, home user public node, operated by [Saiv46](https://t.me/Saiv46), *bandwidth from 60 Mbps to 250 Mbps* (__NO UPTIME GUARANTEES__)
-  * `tcp://176.215.237.83:2755`
-  * `tls://176.215.237.83:2756` **(DEPRECATED)**
+* Irkutsk, home user public node, operated by [Saiv46](https://t.me/Saiv46), *rate-limited to 250 Mbps*
+  * `tcp://irk.peering.flying-squid.host:8080?ed25519=3e77f7671788b8853860b60e9941d12bf539a7f4d2bd7f00e8c36ead9e12c7b2`
+  * `tls://irk.peering.flying-squid.host:8433?ed25519=3e77f7671788b8853860b60e9941d12bf539a7f4d2bd7f00e8c36ead9e12c7b2`
+  * ~~`tcp://176.215.237.83:2755`~~ **(DEPRECATED)**
+  * ~~`tls://176.215.237.83:2756`~~ **(DEPRECATED)**
 
 
 ### Nizhniy Novgorod 
 * Nizhniy Novgorod, node, operated by [Tolstoevsky](https://tolstoevsky.ml)
   * `tcp://95.79.25.190:50001`
   * `tls://95.79.25.190:50002`
-  
-  
+
+
 ### Unknown
 * Public node, operated by ne-vlezay80
   * `tls://[2a01:d0:ffff:4353::2]:6010`

--- a/europe/russia.md
+++ b/europe/russia.md
@@ -41,18 +41,8 @@ Add connection strings from the below list to the `Peers: []` section of your Yg
   * `tls://lan.tdem.in:50002`
 
 
-### Novosibirsk
-* Novosibirsk, public node, operated by [Saiv46](https://t.me/Saiv46), *rate-limited to 200 Mbps*
-  * `tcp://nsk.peering.flying-squid.host:8080?ed25519=f15dceb84a40697471b68f4c04b3620c734478a782e7d844fe2be6ff52ef1f6f`
-  * `tls://nsk.peering.flying-squid.host:8433?ed25519=f15dceb84a40697471b68f4c04b3620c734478a782e7d844fe2be6ff52ef1f6f`
-  * ~~`tcp://91.206.93.65:1333`~~ **(DEPRECATED)**
-  * ~~`tcp://[2a00:b700:2::6:69]:1333`~~ **(DEPRECATED)**
-  * ~~`tls://91.206.93.65:1444`~~ **(DEPRECATED)**
-  * ~~`tls://[2a00:b700:2::6:69]:1444`~~ **(DEPRECATED)**
-
-
 ### Irkutsk
-* Irkutsk, home user public node, operated by [Saiv46](https://t.me/Saiv46), *rate-limited to 250 Mbps*
+* Irkutsk, home user public node, operated by [Saiv46](https://t.me/Saiv46), *bandwidth up to 250 Mbps*
   * `tcp://irk.peering.flying-squid.host:8080?ed25519=3e77f7671788b8853860b60e9941d12bf539a7f4d2bd7f00e8c36ead9e12c7b2`
   * `tls://irk.peering.flying-squid.host:8433?ed25519=3e77f7671788b8853860b60e9941d12bf539a7f4d2bd7f00e8c36ead9e12c7b2`
   * ~~`tcp://176.215.237.83:2755`~~ **(DEPRECATED)**


### PR DESCRIPTION
Changes to public nodes in Russia:
- Added pinning by signing public keys
- Removed Novosibirsk node
- Using subdomains instead of IPs
- Changed ports, old ones are deprecated