### PR TITLE
Add Canada and Kusoneko's Public Peer Node

### DIFF
--- a/north-america/canada.md
+++ b/north-america/canada.md
@@ -3,3 +3,7 @@
 Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
+### Ontario
+
+* Toronto, operated by [Kusoneko](https://github.com/Kusoneko)
+  * `tcp://kusoneko.moe:9002` (Both IPv4 and IPv6)

--- a/north-america/canada.md
+++ b/north-america/canada.md
@@ -1,0 +1,5 @@
+# Canada Peers
+
+Add connection strings from the below list to the `Peers: []` section of your
+Yggdrasil configuration file to peer with these nodes.
+


### PR DESCRIPTION
I wondered why the hell my Yggdrasil connection seemed dead, finally looked at here, and saw that practically all my peers were dead, so I figured I'd add my public peer onto this so that hopefully it doesn't die with hopefully other people peering with it. Also, how the hell is there no Canadian public peers?

Also, let me mention real quick that the neilalexander public peer site listed on the readme is currently dead with a cloudflare 502 error page, so whoever maintains it, if they're here, can hopefully bring it back up eventually.

Kusoneko.