### PR TITLE
add tfnux.org (totem & mercury)

### DIFF
--- a/europe/france.md
+++ b/europe/france.md
@@ -23,3 +23,7 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://[2001:470:1f13:e56::64]:39565`
   * `tls://212.129.52.193:39575`
   * `tls://[2001:470:1f13:e56::64]:39575`
+
+* Paris, Online SAS, operated by [babz](https://tfnux.org)
+  * `tcp://163.172.26.210:25348`
+  * `tcp://[2001:bc8:2495:100::1]:25349`

--- a/europe/netherlands.md
+++ b/europe/netherlands.md
@@ -16,3 +16,7 @@ Yggdrasil configuration file to peer with these nodes.
 * Amsterdam, operated by [deb](https://ysl.su)
   * `tcp://51.15.118.10:62486`
   * `tcp://[2001:bc8:1820:192f::1]:62486`
+
+* Amsterdam, operated by [babz](https://tfnux.org)
+  * `tcp://51.15.3.66:23752`
+  * `tcp://[2001:bc8:2495:200::1]:23753`


### PR DESCRIPTION
totem in Paris, France
mercury in Amsterdam, Netherlands
both hosted by online.net