### PR TITLE
CWINFO Peers

### DIFF
--- a/europe/finland.md
+++ b/europe/finland.md
@@ -8,3 +8,9 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://edge.v6.tku1.devices.y.samip.fi:65444`
   * `tls://edge.v4.tku1.devices.y.samip.fi:65445`
   * `tls://edge.v6.tku1.devices.y.samip.fi:65445`
+
+* Tuusula, Hetzner, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
+  * `tcp://65.21.57.122:53378`
+  * `tcp://[2a01:4f9:c010:664d::1]:53378`
+  * `tls://65.21.57.122:35953`
+  * `tls://[2a01:4f9:c010:664d::1]:35953`

--- a/europe/france.md
+++ b/europe/france.md
@@ -12,12 +12,6 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://51.255.223.60:10259`
   * `tls://[2001:41d0:2:c44a:51:255:223:60]:10259`
 
-* Strasbourg, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tcp://46.105.92.61:52968`
-  * `tcp://[2001:41d0:401:3000::4227]:52968`
-  * `tls://46.105.92.61:39737`
-  * `tls://[2001:41d0:401:3000::4227]:39737`
-
 * Paris, Online SAS, operated by [R4SAS](https://github.com/r4sas)
   * `tcp://212.129.52.193:39565`
   * `tcp://[2001:470:1f13:e56::64]:39565`


### PR DESCRIPTION
- [Peer Removal] – fr2.servers.devices.cwinfo.net
- [New Peer] – fi1.servers.devices.cwinfo.net 