### PR TITLE
Add addAll.py

### DIFF
--- a/addAll.py
+++ b/addAll.py
@@ -2,15 +2,42 @@
 
 import os
 import re
+import socket
 import argparse
 
+def is_ipv4(value):
+    try:
+        socket.inet_aton(value)
+        return True
+    except:
+        return False
+
+def is_ipv6(value):
+    try:
+        socket.inet_pton(socket.AF_INET6, value)
+        return True
+    except:
+        return False
+
+def check_if_domain(value):
+    # Regex from https://github.com/kvesteri/validators/blob/master/validators/domain.py#L5-L10
+    return re.match(
+        r'^(?:[a-zA-Z0-9]'  # First character of the domain
+        r'(?:[a-zA-Z0-9-_]{0,61}[A-Za-z0-9])?\.)'  # Sub domain + hostname
+        r'+[A-Za-z0-9][A-Za-z0-9-_]{0,61}'  # First 61 characters of the gTLD
+        r'[A-Za-z]$'  # Last character of the gTLD
+        , value.split(':')[0]
+    )
+
 if __name__ == "__main__":
-    peer_regex = re.compile(r'\*\s*`(.*?)`')
     parser = argparse.ArgumentParser(description="Yggdrasil Public Peer Compiler")
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-b', '--blacklist', help='blacklists peer file (delimited by space)')
     group.add_argument('-w', '--whitelist', help='whitelists peer file (delimited by space)')
     parser.add_argument('-d', '--peer-directory', default='.', help='peer directory (default pwd)')
+    parser.add_argument('-4', '--ipv4', help='only show ipv4 peers', action='store_true')
+    parser.add_argument('-6', '--ipv6', help='only show ipv6 peers', action='store_true')
+    parser.add_argument('-a', '--dns', help='only show dns peers', action='store_true')
     args = parser.parse_args()
     if args.blacklist is not None:
         args.blacklist.split(' ')
@@ -31,7 +58,33 @@ if __name__ == "__main__":
                 if file.split('.')[-1] == 'md':
                     with open(os.path.join(root, file), 'r') as f:
                         for line in f:
-                            for match in peer_regex.findall(line):
-                                print(match)
+                            for match in re.findall(r'\*\s*`(.*?)`', line):
+                                if args.ipv4 or args.ipv6 or args.dns:
+                                    proto = match.split(':')[0]
+                                    host = match.split('/')[2]
+                                    if proto not in ['tcp','tls']: continue
+
+                                    try:
+                                        if args.ipv4 and is_ipv4(host.split(':')[0]):
+                                                print(match)
+                                                continue
+                                    except:
+                                        pass
+
+                                    try:
+                                        if args.ipv6 and is_ipv6(host.split('[')[1].split(']')[0]):
+                                                print(match)
+                                                continue
+                                    except:
+                                        pass
+
+                                    try:
+                                        if args.dns and check_if_domain(host):
+                                                print(match)
+                                                continue
+                                    except:
+                                        pass
+                                else:
+                                    print(match)
             except:
                 pass

--- a/addAll.py
+++ b/addAll.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import argparse
+
+if __name__ == "__main__":
+    peer_regex = re.compile(r'\*\s*`(.*?)`')
+    parser = argparse.ArgumentParser(description="Yggdrasil Public Peer Compiler")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-b', '--blacklist', help='blacklists peer file (delimited by space)')
+    group.add_argument('-w', '--whitelist', help='whitelists peer file (delimited by space)')
+    parser.add_argument('-d', '--peer-directory', default='.', help='peer directory (default pwd)')
+    args = parser.parse_args()
+    if args.blacklist is not None:
+        args.blacklist.split(' ')
+    if args.whitelist is not None:
+        args.whitelist.split(' ')
+
+    for root, dirs, files in os.walk(args.peer_directory):
+        if os.path.relpath(root, args.peer_directory) not in ['asia', 'europe', 'north-america', 'other', 'south-america']:
+            continue
+
+        for file in files:
+            if args.blacklist is not None and file.split('.')[0].lower() in args.blacklist.split('.')[0].lower():
+                continue
+            if args.whitelist is not None and file.split('.')[0].lower() not in args.whitelist.split('.')[0].lower():
+                continue
+
+            try:
+                if file.split('.')[-1] == 'md':
+                    with open(os.path.join(root, file), 'r') as f:
+                        for line in f:
+                            for match in peer_regex.findall(line):
+                                print(match)
+            except:
+                pass

--- a/europe/belarus.md
+++ b/europe/belarus.md
@@ -1,8 +1,0 @@
-# Belarus Peers
-
-Add connection strings from the below list to the `Peers: []` section of your Yggdrasil configuration file to peer with these nodes.
-
-### Gomel
-* Gomel region. Operated by [eugene_martein](https://t.me/eugene_martein)
-  * `tcp://178.172.152.62:7991`
-  * `tls://178.172.152.62:7992`

--- a/europe/finland.md
+++ b/europe/finland.md
@@ -8,3 +8,9 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://edge.v6.tku1.devices.y.samip.fi:65444`
   * `tls://edge.v4.tku1.devices.y.samip.fi:65445`
   * `tls://edge.v6.tku1.devices.y.samip.fi:65445`
+
+* Tuusula, Hetzner, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
+  * `tcp://65.21.57.122:53378`
+  * `tcp://[2a01:4f9:c010:664d::1]:53378`
+  * `tls://65.21.57.122:35953`
+  * `tls://[2a01:4f9:c010:664d::1]:35953`

--- a/europe/france.md
+++ b/europe/france.md
@@ -17,3 +17,7 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://[2001:470:1f13:e56::64]:39565`
   * `tls://212.129.52.193:39575`
   * `tls://[2001:470:1f13:e56::64]:39575`
+
+* Paris, Online SAS, operated by [babz](https://tfnux.org)
+  * `tcp://163.172.26.210:25348`
+  * `tcp://[2001:bc8:2495:100::1]:25349`

--- a/europe/france.md
+++ b/europe/france.md
@@ -12,12 +12,6 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://51.255.223.60:10259`
   * `tls://[2001:41d0:2:c44a:51:255:223:60]:10259`
 
-* Strasbourg, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tcp://46.105.92.61:52968`
-  * `tcp://[2001:41d0:401:3000::4227]:52968`
-  * `tls://46.105.92.61:39737`
-  * `tls://[2001:41d0:401:3000::4227]:39737`
-
 * Paris, Online SAS, operated by [R4SAS](https://github.com/r4sas)
   * `tcp://212.129.52.193:39565`
   * `tcp://[2001:470:1f13:e56::64]:39565`

--- a/europe/germany.md
+++ b/europe/germany.md
@@ -7,9 +7,7 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://82.165.69.111:61216`
   * `tcp://[2001:8d8:1800:8224::1]:61216`
 
-* Mauern, [Phreedom](https://phreedom.club) public node, operated by [Tolstoevsky](https://rawtext.club/~tolstoevsky)
-  * `tcp://45.11.19.26:5001` - going down April 2021
-  * `tls://45.11.19.26:5002` - going down  April 2021
+* Mauern, [Phreedom](https://phreedom.club) public node, operated by [Tolstoevsky](https://phreedom.club/~tolstoevsky)
   * `tcp://45.138.172.192:5001` - going down June 2021
   * `tls://45.138.172.192:5002` - going down June 2021
 

--- a/europe/germany.md
+++ b/europe/germany.md
@@ -17,3 +17,7 @@ Yggdrasil configuration file to peer with these nodes.
 
 * Falkenstein, public node hosted on a Hetzner Online GmbH dedicated server
   * `tcp://94.130.203.208:5999`
+
+* Public node hosted on msk.host (500 Mbit/s), operated by @cofob:kde.org (matrix)
+  * `tcp://51.89.92.114:5555`
+  * `tls://51.89.92.114:5556`

--- a/europe/netherlands.md
+++ b/europe/netherlands.md
@@ -16,3 +16,7 @@ Yggdrasil configuration file to peer with these nodes.
 * Amsterdam, operated by [deb](https://ysl.su)
   * `tcp://51.15.118.10:62486`
   * `tcp://[2001:bc8:1820:192f::1]:62486`
+
+* Amsterdam, operated by [babz](https://tfnux.org)
+  * `tcp://51.15.3.66:23752`
+  * `tcp://[2001:bc8:2495:200::1]:23753`

--- a/europe/russia.md
+++ b/europe/russia.md
@@ -22,6 +22,10 @@ Add connection strings from the below list to the `Peers: []` section of your Yg
   * `tcp://37.230.116.83:5353`
   * `tcp://[2a01:230:2::208]:5353`
 
+* Moscow, vps public node, operated by [Shurale](https://github.com/shurale) *Rate-limited to 100 Mbit/s*
+  * `tcp://185.228.233.50:60575`
+  * `tls://185.228.233.50:8443`
+
 
 ### Saint Petersburg
 * Saint Petersburg, loskiq public node, operated by [loskiq](https://loskiq.dev)


### PR DESCRIPTION
Add a script that compiles all Yggdrasil public peers so you could add them to /etc/yggdrasil.conf. Something like https://github.com/hyperboria/peers/pull/159

Using `-4`,`-6`,`-a` excludes tor and i2p nodes because it filters out everything that doesn't use tcp or tls protocol.

Example use:

* `./addAll.py -4` (add all nodes with ipv4 addresses) 
* `./addAll.py -4a` (add all nodes with ipv4 and hostnames)
* `./addAll.py -b "tor i2p"` (adds all peers except tor and i2p)
* `./addAll.py -w "tor"` (add only tor nodes)
* `./addAll.py` (add everything) 