### PR TITLE
CWINFO & Warén Group – New Peers & Updated Peers

### DIFF
--- a/europe/finland.md
+++ b/europe/finland.md
@@ -13,3 +13,8 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://fi1.servers.devices.cwinfo.net:61995`
   * `tls://65.21.57.122:61995`
   * `tls://[2a01:4f9:c010:664d::1]:61995`
+
+* Tuusula, Hetzner, operated by [warengroup](https://waren.io) and [cwchristerw](https://christerwaren.fi)
+  * `tls://aurora.devices.waren.io:18836`
+  * `tls://95.216.5.243:18836`
+  * `tls://[2a01:4f9:2a:60c::2]:18836`

--- a/europe/finland.md
+++ b/europe/finland.md
@@ -10,7 +10,6 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://edge.v6.tku1.devices.y.samip.fi:65445`
 
 * Tuusula, Hetzner, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tcp://65.21.57.122:53378`
-  * `tcp://[2a01:4f9:c010:664d::1]:53378`
-  * `tls://65.21.57.122:35953`
-  * `tls://[2a01:4f9:c010:664d::1]:35953`
+  * `tls://fi1.servers.devices.cwinfo.net:61995`
+  * `tls://65.21.57.122:61995`
+  * `tls://[2a01:4f9:c010:664d::1]:61995`

--- a/europe/france.md
+++ b/europe/france.md
@@ -3,6 +3,11 @@
 Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
+* Gravelines, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
+  * `tls://fr2.servers.devices.cwinfo.net:23108`
+  * `tls://152.228.216.112:23108`
+  * `tls://[2001:41d0:304:200::ace3]:23108`
+
 * Paris, operated by [Arceliar](https://github.com/Arceliar)
   * `tcp://51.15.204.214:12345`
   * `tls://51.15.204.214:54321`

--- a/europe/france.md
+++ b/europe/france.md
@@ -8,10 +8,9 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://51.15.204.214:54321`
 
 * Roubaix, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tcp://51.255.223.60:26409`
-  * `tcp://[2001:41d0:2:c44a:51:255:223:60]:26409`
-  * `tls://51.255.223.60:10259`
-  * `tls://[2001:41d0:2:c44a:51:255:223:60]:10259`
+  * `tls://cloudberry.fr1.servers.devices.cwinfo.net:54232`
+  * `tls://51.255.223.60:54232`
+  * `tls://[2001:41d0:2:c44a:51:255:223:60]:54232`
 
 * Paris, Online SAS, operated by [R4SAS](https://github.com/r4sas)
   * `tcp://212.129.52.193:39565`

--- a/europe/poland.md
+++ b/europe/poland.md
@@ -4,10 +4,9 @@ Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
 * Warsaw, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tcp://54.37.137.221:37145`
-  * `tcp://[2001:41d0:601:1100::cf2]:37145`
-  * `tls://54.37.137.221:14987`
-  * `tls://[2001:41d0:601:1100::cf2]:14987`
+  * `tls://pl1.servers.devices.cwinfo.net:11129`
+  * `tls://54.37.137.221:11129`
+  * `tls://[2001:41d0:601:1100::cf2]:11129`
 
 * Warsaw, OVH hosting, [Network Neighborhood](http://netwhood.online) public node, operated by [abslimit](http://netwhood.online/feedback/)
   * `tcp://51.75.44.73:50001`

--- a/europe/united-kingdom.md
+++ b/europe/united-kingdom.md
@@ -5,5 +5,10 @@ Yggdrasil configuration file to peer with these nodes.
 
 ### England
 
+* London, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
+  * `tls://uk1.servers.devices.cwinfo.net:28395`
+  * `tls://51.38.64.12:28395`
+  * `tls://[2001:41d0:801:2000::233f]:28395`
+
 * London, operated by [Tom Snelling](https://tdjs.tech)
   * `tcp://curiosity.tdjs.tech:30003`

--- a/north-america/canada.md
+++ b/north-america/canada.md
@@ -5,6 +5,11 @@ Yggdrasil configuration file to peer with these nodes.
 
 ### Ontario
 
+* Beauharnois, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
+  * `tls://ca1.servers.devices.cwinfo.net:58226`
+  * `tls://192.99.145.61:58226`
+  * `tls://[2607:5300:201:3100::50a1]:58226`
+
 * Toronto, operated by [Kusoneko](https://github.com/Kusoneko)
   * `tcp://kusoneko.moe:9002` (Both IPv4 and IPv6)
 


### PR DESCRIPTION
**CWINFO**
- cloudberry.fr1.servers.devices.cwinfo.net
- fr2.servers.devices.cwinfo.net
- pl1.servers.devices.cwinfo.net
- fi1.servers.devices.cwinfo.net
- uk1.servers.devices.cwinfo.net [+]
- ca1.servers.devices.cwinfo.net [+]

**Warén Group**
- aurora.devices.waren.io [+]