### PR TITLE
Update IPv6 address

### DIFF
--- a/europe/netherlands.md
+++ b/europe/netherlands.md
@@ -22,4 +22,4 @@ Yggdrasil configuration file to peer with these nodes.
 
 * Rotterdam, operated by [tomz](https://gitlab.com/tomzander)
   * `tls://77.95.229.240:62486`
-  * `tls://[2a00:7b80:3013::1]:62486`
+  * `tls://[2a00:7b80:3013:bc5::]:62486`


### PR DESCRIPTION
After noticing the peer being offline on the tracker, I checked and this seems to now be the proper IP address.