### PR TITLE
[URGENT] Update russia.md

### DIFF
--- a/europe/russia.md
+++ b/europe/russia.md
@@ -56,8 +56,8 @@ Add connection strings from the below list to the `Peers: []` section of your Yg
 
 ### Irkutsk
 * Irkutsk, home user public node, operated by [Saiv46](https://matrix.to/#/@saiv46:tomesh.net), *IPv4 only*
-  * `tcp://irk.peering.flying-squid.host:8080?key=f69da2c11d5fe8bcee7d026a6ed28dc7873db9ecb88c797b29348546e411d934`
-  * `tls://irk.peering.flying-squid.host:8443?key=f69da2c11d5fe8bcee7d026a6ed28dc7873db9ecb88c797b29348546e411d934`
+  * `tcp://176.215.237.83:8080?sni=irk.peering.flying-squid.host&key=f69da2c11d5fe8bcee7d026a6ed28dc7873db9ecb88c797b29348546e411d934`
+  * `tls://176.215.237.83:8443?sni=irk.peering.flying-squid.host&key=f69da2c11d5fe8bcee7d026a6ed28dc7873db9ecb88c797b29348546e411d934`
 
 
 ### Unknown


### PR DESCRIPTION
Some domain registers decides to terminate service for users registered in Russia.

Domains affected:
`irk.entrypoint.flying-squid.host` (will be unavailable March 23, 2022)