### PR TITLE
Additional public peers in Brazil, Poland and Netherlands.

### DIFF
--- a/europe/netherlands.md
+++ b/europe/netherlands.md
@@ -38,3 +38,9 @@ Yggdrasil configuration file to peer with these nodes.
   * `tcp://aaoth.xyz:7777`
   * `tcp://95.179.155.103:7777`
   * `tcp://[2001:19f0:5001:3579::1]:7777`
+
+* Flevoland/Dronten, operated by [igorhvr](https://www.iasylum.net/)
+  * `tcp://ipv4.dronten.flevoland.netherlands.iasylum.net:40000`
+  * `tcp://ipv6.dronten.flevoland.netherlands.iasylum.net:41000`
+  * `tls://ipv4.dronten.flevoland.netherlands.iasylum.net:50000`
+  * `tls://ipv6.dronten.flevoland.netherlands.iasylum.net:51000`

--- a/europe/poland.md
+++ b/europe/poland.md
@@ -7,3 +7,9 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://pl1.servers.devices.cwinfo.net:11129`
   * `tls://54.37.137.221:11129`
   * `tls://[2001:41d0:601:1100::cf2]:11129`
+
+* Warsaw, OVH, operated by [igorhvr](https://www.iasylum.net/)
+  * `tcp://ipv4.warsaw.poland.yggdrasil.iasylum.net:40000`
+  * `tcp://ipv6.warsaw.poland.yggdrasil.iasylum.net:41000`
+  * `tls://ipv4.warsaw.poland.yggdrasil.iasylum.net:50000`
+  * `tls://ipv6.warsaw.poland.yggdrasil.iasylum.net:51000`

--- a/south-america/brazil.md
+++ b/south-america/brazil.md
@@ -6,3 +6,9 @@ Yggdrasil configuration file to peer with these nodes.
 * São Paulo, operated by Yan Minari from [Malha](https://malha.global/)
   * `tcp://45.231.133.188:58301`
   * `tcp://[2804:49fc::ffff:ffff:5b5:e8be]:58301`
+
+* Campina Grande, Paraíba, operated by [igorhvr](https://www.iasylum.net/)
+  * `tcp://ipv4.campina-grande.paraiba.brazil.yggdrasil.iasylum.net:40000`
+  * `tcp://ipv6.campina-grande.paraiba.brazil.yggdrasil.iasylum.net:41000`
+  * `tls://ipv4.campina-grande.paraiba.brazil.yggdrasil.iasylum.net:50000`
+  * `tls://ipv6.campina-grande.paraiba.brazil.yggdrasil.iasylum.net:51000`


### PR DESCRIPTION
Additional public peers in Brazil, Poland and Netherlands - all accessible by ipv4 and ipv6 and both directly and through tls.