### PR TITLE
correct peer info for Virginia ovh

### DIFF
--- a/north-america/united-states.md
+++ b/north-america/united-states.md
@@ -78,4 +78,4 @@ Yggdrasil configuration file to peer with these nodes.
 ### Virginia
 * OVH virginia, operated by jeff
   * `tcp://51.81.46.170:5000`
-  * `tcp://51.81.46.170:5222`
+  * `tls://51.81.46.170:5222`


### PR DESCRIPTION
tls NOT tcp