### PR TITLE
add new peer and update infos

### DIFF
--- a/europe/germany.md
+++ b/europe/germany.md
@@ -22,8 +22,8 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://ygg1.mk16.de:1338?key=0000000087ee9949eeab56bd430ee8f324cad55abf3993ed9b9be63ce693e18a`
 
 * Nuremberg, hosted on Netcup, operated by [Marek Küthe](https://mk16.de/)
-  * `tcp://p2p-node.de:1337?key=000000d80a2d7b3126ea65c8c08fc751088c491a5cdd47eff11c86fa1e4644ae`
-  * `tls://p2p-node.de:1338?key=000000d80a2d7b3126ea65c8c08fc751088c491a5cdd47eff11c86fa1e4644ae`
+  * `tcp://ygg2.mk16.de:1337?key=000000d80a2d7b3126ea65c8c08fc751088c491a5cdd47eff11c86fa1e4644ae`
+  * `tls://ygg2.mk16.de:1338?key=000000d80a2d7b3126ea65c8c08fc751088c491a5cdd47eff11c86fa1e4644ae`
 
 * Hetzner, Nürnberg
   * `tls://vpn.ltha.de:443?key=0000006149970f245e6cec43664bce203f2514b60a153e194f31e2b229a1339d`

--- a/north-america/united-states.md
+++ b/north-america/united-states.md
@@ -59,6 +59,10 @@ Yggdrasil configuration file to peer with these nodes.
 
 * Portland, OR (10Gbit, AWS ARM64) operated by [christoofar](https://github.com/christoofar)
   * `tls://44.234.134.124:443`
+  
+* hosted by Evolution Host via OVH SAS, operated by [Marek Küthe](https://mk16.de/)
+  * `tcp://ygg3.mk16.de:1337?key=000003acdaf2a60e8de2f63c3e63b7e911d02380934f09ee5c83acb758f470c1`
+  * `tls://ygg3.mk16.de:1338?key=000003acdaf2a60e8de2f63c3e63b7e911d02380934f09ee5c83acb758f470c1`
 
 ### Texas
 


### PR DESCRIPTION
The domain name "p2p-node.de" is retained. However, I would like to bring some order into the DNS. Therefore the change for the name.

Furthermore I got a server from Evolution Host against advertising on my website, on which I run Yggdrasil.

Signed-off-by: Marek Küthe <m.k@mk16.de>