### PR TITLE
Update united-states.md

### DIFF
--- a/north-america/united-states.md
+++ b/north-america/united-states.md
@@ -75,7 +75,7 @@ Yggdrasil configuration file to peer with these nodes.
 
 * Ft. Worth, TX operated by [christoofar](https://github.com/christoofar)
   * `tls://cowboy.supergay.network:443`
-  * `tcp://cowboy.supergay.network:9001`
+  * `tcp://cowboy.supergay.network:9111`
 
 ### Washington
 


### PR DESCRIPTION
Correcting the port number on the Ft. Worth tcp endpoint.  The correct port number is 9111