### PR TITLE
CWINFO Peers

### DIFF
--- a/europe/france.md
+++ b/europe/france.md
@@ -15,7 +15,7 @@ Yggdrasil configuration file to peer with these nodes.
 * Roubaix, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
   * `tls://cloudberry.fr1.servers.devices.cwinfo.net:54232`
   * `tls://51.255.223.60:54232`
-  * `tls://[2001:41d0:2:c44a:51:255:223:60]:54232`
+  * `tls://[2001:41d0:303:13b3:51:255:223:60]:54232`
 
 * Paris, Online SAS, operated by [R4SAS](https://github.com/r4sas)
   * `tcp://s2.i2pd.xyz:39565`


### PR DESCRIPTION
Update IPv6 to cloudberry.fr1.servers.devices.cwinfo.net