### PR TITLE
Fixed spacing for my existing entry

### DIFF
--- a/north-america/united-states.md
+++ b/north-america/united-states.md
@@ -60,7 +60,7 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://ygg3.mk16.de:1338?key=000003acdaf2a60e8de2f63c3e63b7e911d02380934f09ee5c83acb758f470c1`
 
 * Hillsboro, OR (Hetzner, AMD x86, IPv4 + IPv6)
- * `tls://ygg.mnpnk.com:443`
+  * `tls://ygg.mnpnk.com:443`
 
 ### Texas
 


### PR DESCRIPTION
Fixed my spacing. The incorrect spacing was causing the server entry to not be a child of the parent. Sorry to take up your resources with this trivial stuff.