### PR TITLE
Update russia.md (antebeot.ru domain address to IP)

### DIFF
--- a/europe/russia.md
+++ b/europe/russia.md
@@ -90,8 +90,8 @@ Add connection strings from the below list to the `Peers: []` section of your Yg
 ### Novosibirsk
 
 * Novoibirsk, home user public node, operated by WipedLife *bandwidth up to 500 Mbps*
-  * `tcp://antebeot.ru:7890`
-  * `tls://antebeot.ru:7891`
+  * `tcp://94.180.118.146:7890`
+  * `tls://94.180.118.146:7891`
 
 * Novoibirsk, public node, operated by [sergeysedoy97](https://t.me/sergeysedoy97), 200 Mbit/s, IPv6 Only
   * `tls://x-ovb-0.sergeysedoy97.ru:65535`


### PR DESCRIPTION
Reg.ru is blocked my domain that known as "antebeot.ru". Also them blocked access to their website by my home IP address. So. For a while and on (for) future I would to change this address on my IP. In my life place exist much of strange people, so I would be more careful in future, but for now, my appologize. I would to change my domain address there on my home IP for users that want to use yggdrasil though my peer. My home IP can't be blocked so easy like domain.