### PR TITLE
other/{i2p,tor}.md: remove PPFI peer

### DIFF
--- a/other/i2p.md
+++ b/other/i2p.md
@@ -8,9 +8,6 @@ Note that the following assumes I2P is running locally and has configured SOCKS 
 * ST32 (TCP-only, Standard I2P service, b32 address), operated by [cathugger](http://cathugger.i2p/contact.html)
   * `socks://localhost:4447/7mx6ztmimo5nrnmydjjtkr6maupknr3zlyr33umly22pqnivyxcq.b32.i2p:46944`
 
-* ST32 (TCP-only, Standard I2P service, b32 address, operated by [Mikaela](https://mikaela.info/) on behalf of [Pirate Party Finland](https://piraattipuolue.fi/en) ([Tor Metrics](https://metrics.torproject.org/rs.html#details/796338999A7E34CA4C0F2C6092618C82C0D335D9))
-  * `socks://localhost:4447/gqt6l2wox5jndysfllrgdr6mp473t24mdi7f3iz6lugpzv3z67wq.b32.i2p:63412`
-
 * Home yggdrasil i2p node from brocken pc:
   * `socks://localhost:4447/i6lbsjw7kh4gqmbylcsjtfh3juj3dbbk24bwzrpgvtalhs7xagoa.b32.i2p:2721`
 

--- a/other/tor.md
+++ b/other/tor.md
@@ -15,9 +15,6 @@ Note that the following assumes Tor is running locally and listening on the defa
 * HS3 (TCP-only, Hidden Service, v3), operated by [cathugger](http://cathug2kyi4ilneggumrenayhuhsvrgn6qv2y47bgeet42iivkpynqad.onion/contact.html)
   * `socks://localhost:9050/yggnekkmyitzepgl5ltdl277y5wdg36n4pc45sualo3yesm3usnuwyad.onion:1863`
 
-* HS3 (TCP-only, Hidden Service, v3), operated by [Mikaela](https://mikaela.info/) on behalf of [Pirate Party Finland](https://piraattipuolue.fi/en) ([Tor Metrics](https://metrics.torproject.org/rs.html#details/796338999A7E34CA4C0F2C6092618C82C0D335D9))
-  * `socks://localhost:9050/x7dqdmjb7y5ykj4kgirwzj62wrrd3t5dv57oy7oyidnf7cpthd4k7ryd.onion:5222`
-
 * HS3 (TCP-only, Hidden Service, v3), operated by [opal hart](http://opalwxdqzyuwo2vbipp3facjuuztfjwauai7fghh2ggbcl7enuvfg6yd.onion/contact.xht)
   *  `socks://localhost:9050/nxuwjikhsirri2rbrdlphstsn3jr2qzjrsylwkt65rh2miycr5n24tid.onion:706`
   *  `socks://localhost:9050/fllrj72kxnenalmmi3uz22ljqnmuex4h2jlhwnapxlzrnn7lknadxuqd.onion:706`


### PR DESCRIPTION
We no longer have the office where the peer was physically and it's unlikely to return.

In the end it was also hosted by _Teknologia Avoimeksi ry_ for a couple of years, but I never remembered to update it here. I would have been the contact person regardless.