### PR TITLE
CWINFO Peers - fi1.servers.devices.cwinfo.net

### DIFF
--- a/europe/finland.md
+++ b/europe/finland.md
@@ -6,6 +6,7 @@ Yggdrasil configuration file to peer with these nodes.
 * Tuusula, Hetzner, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
   * `tls://fi1.servers.devices.cwinfo.net:61995`
   * `tls://65.21.57.122:61995`
+  * `tls://[2a01:4f9:c012:a8df::1]:61995`
 
 * Tuusula, Hetzner, operated by [warengroup](https://waren.io) and [cwchristerw](https://christerwaren.fi)
   * `tls://aurora.devices.waren.io:18836`


### PR DESCRIPTION
New IPv6 address for fi1.servers.devices.cwinfo.net