### PR TITLE
New peering method for mima.localghost.org

### DIFF
--- a/asia/philippines.md
+++ b/asia/philippines.md
@@ -4,5 +4,4 @@ Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
 * Manila, LightNode, VPS, operated by [Mima-sama](http://mima.localghost.org)
-  * `tcp://mima.localghost.org:1996`
-  * `tls://mima.localghost.org:1997`
+  * `tls://mima.localghost.org:443`


### PR DESCRIPTION
Ports 1996 (tcp), 1997 (tls), and 1998 (quic) will all be decommissioned in 5 September 2024 in favor of a simple TLS listener at port 443.