### PR TITLE
added tls://london.sabretruth.org:18472 which has permanent IP

### DIFF
--- a/europe/united-kingdom.md
+++ b/europe/united-kingdom.md
@@ -6,3 +6,6 @@ Yggdrasil configuration file to peer with these nodes.
 * Equinix, Manchester, operated by neilalexander
   * `tls://uk.yggdrasil.neilalexander.dev:64648?key=c936c2171cf36fb4326acc644f83e367d0224b9e5b65bd97073c91e6d9d96559`
   * `quic://uk.yggdrasil.neilalexander.dev:64648?key=c936c2171cf36fb4326acc644f83e367d0224b9e5b65bd97073c91e6d9d96559`
+
+* London, operated by sabretruth.org
+  * `tls://london.sabretruth.org:18472`

--- a/europe/united-kingdom.md
+++ b/europe/united-kingdom.md
@@ -9,3 +9,4 @@ Yggdrasil configuration file to peer with these nodes.
 
 * London, operated by sabretruth.org
   * `tls://london.sabretruth.org:18472`
+  * `tcp://london.sabretruth.org:18473`


### PR DESCRIPTION
Been running this node as test for a while now seems reliable. It's my main peer for a few servers but happy to show it out to others. It's a dedicated dual core VPS with 1Gbps of umetered outbound bandwidth. 