### PR TITLE
Removing decommisioned CWINFO servers

### DIFF
--- a/europe/france.md
+++ b/europe/france.md
@@ -8,11 +8,6 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://51.255.223.60:54232`
   * `tls://[2001:41d0:303:13b3:51:255:223:60]:54232`
 
-* Gravelines, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tls://fr2.servers.devices.cwinfo.net:23108`
-  * `tls://152.228.216.112:23108`
-  * `tls://[2001:41d0:304:200::ace3]:23108`
-
 * Paris, operated by [Arceliar](https://github.com/Arceliar)
   * `tcp://51.15.204.214:12345`
   * `tls://51.15.204.214:54321`

--- a/europe/poland.md
+++ b/europe/poland.md
@@ -3,10 +3,5 @@
 Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
-* Warsaw, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tls://pl1.servers.devices.cwinfo.net:11129`
-  * `tls://54.37.137.221:11129`
-  * `tls://[2001:41d0:601:1100::cf2]:11129`
-
 * Opole, self-hosted on residential fibre (traffic proxied via VPS in Netherlands), 500Mbps (without proxy overhead), operated by [l1qu1d.net](https://l1qu1d.net) and [0x1a8510f2](https://0x1a8510f2.space)
   * `quic://0.ygg.l1qu1d.net:11102?key=0000000998b5ff8c0f1115ce9212f772d0427151f50fe858e6de1d22600f1680`


### PR DESCRIPTION
We have decommisioned following servers
- fr2.servers.devices.cwinfo.net
- pl1.servers.devices.cwinfo.net