### PR TITLE
Changing ports of my nodes, splitting ipv4 and ipv6 URLs, adding pub keys

### DIFF
--- a/europe/germany.md
+++ b/europe/germany.md
@@ -37,9 +37,11 @@ Yggdrasil configuration file to peer with these nodes.
   * `tls://x-fra-0.sergeysedoy97.ru:65534`
   * `tls://s-fra-0.sergeysedoy97.ru:65534` *Dual-Stack by Cloudflare Spectrum*
   * `quic://x-fra-0.sergeysedoy97.ru:65535`
-* Frankfurt, VPS, IPv4 Only, 2Gbps operated by [lcharles123](https://github.com/lcharles123)
-  * `tcp://89.117.152.94:65535`
-  * `quic://89.117.152.94:65535`
+* Frankfurt, VPS, 2Gbps operated by [lcharles123](https://github.com/lcharles123)
+  * `tcp://ip4.fvm.mywire.org:8080?key=000000000143db657d1d6f80b5066dd109a4cb31f7dc6cb5d56050fffb014217`
+  * `quic://ip4.fvm.mywire.org:443?key=000000000143db657d1d6f80b5066dd109a4cb31f7dc6cb5d56050fffb014217`
+  * `tcp://ip6.fvm.mywire.org:8080?key=000000000143db657d1d6f80b5066dd109a4cb31f7dc6cb5d56050fffb014217`
+  * `quic://ip6.fvm.mywire.org:443?key=000000000143db657d1d6f80b5066dd109a4cb31f7dc6cb5d56050fffb014217`
 
 * Frankfurt, VPS with 10Gb/s, operated by [Revertron](https://github.com/Revertron)
   * `tcp://193.107.20.230:7743`

--- a/north-america/united-states.md
+++ b/north-america/united-states.md
@@ -7,9 +7,11 @@ Yggdrasil configuration file to peer with these nodes.
 
 * San Francisco, Digital Ocean, VPS, operated by [marioaugustorama](https://github.com/marioaugustorama)
   * `tcp://165.227.17.198:9002`
-* Los Angeles, Racknerd, IPv4/v6, 1Gbps operated by [lcharles123](https://github.com/lcharles123)
-  * `tcp://nerdvm.mywire.org:65535`
-  * `quic://nerdvm.mywire.org:65535`
+* Los Angeles, Racknerd, IPv4/v6, 1Gbps, meteded, operated by [lcharles123](https://github.com/lcharles123)
+  * `tcp://ip4.nerdvm.mywire.org:8080`
+  * `quic://ip4.nerdvm.mywire.org:443`
+  * `tcp://ip6.nerdvm.mywire.org:8080`
+  * `quic://ip6.nerdvm.mywire.org:443`
 
 ### Florida
 

--- a/north-america/united-states.md
+++ b/north-america/united-states.md
@@ -8,10 +8,10 @@ Yggdrasil configuration file to peer with these nodes.
 * San Francisco, Digital Ocean, VPS, operated by [marioaugustorama](https://github.com/marioaugustorama)
   * `tcp://165.227.17.198:9002`
 * Los Angeles, Racknerd, IPv4/v6, 1Gbps, meteded, operated by [lcharles123](https://github.com/lcharles123)
-  * `tcp://ip4.nerdvm.mywire.org:8080`
-  * `quic://ip4.nerdvm.mywire.org:443`
-  * `tcp://ip6.nerdvm.mywire.org:8080`
-  * `quic://ip6.nerdvm.mywire.org:443`
+  * `tcp://ip4.nerdvm.mywire.org:8080?key=6342592a45a234afce0966610217f798e4898f6b1607d354fb126c239d05abf7`
+  * `quic://ip4.nerdvm.mywire.org:443?key=6342592a45a234afce0966610217f798e4898f6b1607d354fb126c239d05abf7`
+  * `tcp://ip6.nerdvm.mywire.org:8080?key=6342592a45a234afce0966610217f798e4898f6b1607d354fb126c239d05abf7`
+  * `quic://ip6.nerdvm.mywire.org:443?key=6342592a45a234afce0966610217f798e4898f6b1607d354fb126c239d05abf7`
 
 ### Florida
 


### PR DESCRIPTION
Ports are now 443 for quic and 8080 for tcp