### PR TITLE
Update brazil.md

### DIFF
--- a/south-america/brazil.md
+++ b/south-america/brazil.md
@@ -7,3 +7,9 @@ Yggdrasil configuration file to peer with these nodes.
 
 * Formiga, consumer grade connection, 3-10 Mbps, IPv6-only
   * `quic://ip6.casa2.mywire.org:44443?key=af4885c078c705dc0e21a696171f3d7878c48bd47164571590f29f38ed5a4573`
+
+### Sao Paulo
+
+* Sao Paulo, VPS, operated by [Fijxu (nadeko.net)](https://nadeko.net), 500 Mbit/s, IPV4
+  * `tcp://ygg.nadeko.net:44441`
+  * `tls://ygg.nadeko.net:44442`


### PR DESCRIPTION
Adds a brazil node ran by me

Speedtests:

```
iperf3 Network Speed Tests (IPv4):
---------------------------------
Provider        | Location (Link)           | Send Speed      | Recv Speed      | Ping           
-----           | -----                     | ----            | ----            | ----           
Clouvider       | London, UK (10G)          | 660 Mbits/sec   | 395 Mbits/sec   | 196 ms         
Eranium         | Amsterdam, NL (100G)      | 949 Mbits/sec   | 645 Mbits/sec   | 183 ms         
Uztelecom       | Tashkent, UZ (10G)        | busy            | 197 Mbits/sec   | 277 ms         
Leaseweb        | Singapore, SG (10G)       | busy            | 37.3 Mbits/sec  | 343 ms         
Clouvider       | Los Angeles, CA, US (10G) | 944 Mbits/sec   | 292 Mbits/sec   | --             
Leaseweb        | NYC, NY, US (10G)         | 1.50 Gbits/sec  | 285 Mbits/sec   | 113 ms         
Edgoo           | Sao Paulo, BR (1G)        | 1.68 Gbits/sec  | 1.23 Gbits/sec  | 2.31 ms     
```