### PR TITLE
Remove deprecated CWINFO peers

### DIFF
--- a/europe/finland.md
+++ b/europe/finland.md
@@ -3,11 +3,6 @@
 Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
-* Tuusula, Hetzner, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tls://fi1.servers.devices.cwinfo.net:61995`
-  * `tls://65.21.57.122:61995`
-  * `tls://[2a01:4f9:c012:a8df::1]:61995`
-
 * Tuusula, Hetzner, operated by [warengroup](https://waren.io) and [cwchristerw](https://christerwaren.fi)
   * `tls://aurora.devices.waren.io:18836`
   * `tls://95.216.5.243:18836`

--- a/europe/france.md
+++ b/europe/france.md
@@ -3,11 +3,6 @@
 Add connection strings from the below list to the `Peers: []` section of your
 Yggdrasil configuration file to peer with these nodes.
 
-* Gravelines, OVH, operated by [cwinfo](https://cwinfo.net) and [cwchristerw](https://christerwaren.fi)
-  * `tls://cloudberry.fr1.servers.devices.cwinfo.net:54232`
-  * `tls://51.255.223.60:54232`
-  * `tls://[2001:41d0:303:13b3:51:255:223:60]:54232`
-
 * Paris, operated by [Arceliar](https://github.com/Arceliar)
   * `tcp://51.15.204.214:12345`
   * `tls://51.15.204.214:54321`


### PR DESCRIPTION
We have deprecated following servers
- cloudberry.fr1.servers.devices.cwinfo.net
- fi1.servers.devices.cwinfo.net