### PR TITLE
Revert "Update yggdrasil chat link"

### DIFF
--- a/europe/russia.md
+++ b/europe/russia.md
@@ -1,6 +1,6 @@
 # Russia Peers
 
-Operators of Yggdrasil public peers in Russia should consider joining the [Russian Meshnet](https://github.com/russian-meshnet/meshnet-chat-agenda/blob/master/README.md#чаты-и-мосты-в-разных-сетях) and [Yggdrasil of the Renegades](https://github.com/DomesticMoth/shiny-octo-computing-machine) community channels!
+Operators of Yggdrasil public peers in Russia should consider joining the [Russian Meshnet](https://github.com/russian-meshnet/meshnet-chat-agenda/blob/master/README.md#чаты-и-мосты-в-разных-сетях) and [Yggdrasil RU](https://t.me/Yggdrasil_ru) community channels!
 
 Add connection strings from the below list to the `Peers: []` section of your Yggdrasil configuration file to peer with these nodes.
 


### PR DESCRIPTION
Reverts yggdrasil-network/public-peers#411

Ironically, link for a "fork" is died while previous chat is still available.